### PR TITLE
destructure factory for smaller output

### DIFF
--- a/lib/PlainSerializer.js
+++ b/lib/PlainSerializer.js
@@ -7,7 +7,7 @@ class PlainSerializer {
     const blankNodesString = [
       '  const blankNodes = []',
       `  for (let i = 0; i < ${blankNodes.size}; i++) {`,
-      '    blankNodes.push(factory.blankNode())',
+      '    blankNodes.push(blankNode())',
       '  }',
       ''
     ].join('\n')
@@ -15,7 +15,7 @@ class PlainSerializer {
     return [
       '/* This file was automatically generated. Do not edit by hand. */',
       '',
-      'module.exports = factory => {',
+      'module.exports = ({ blankNode, literal, namedNode, quad }) => {',
       blankNodes.size !== 0 ? blankNodesString : null,
       quadsString ? `  return [\n${quadsString}\n  ]` : '  return []',
       '}',
@@ -34,18 +34,18 @@ class PlainSerializer {
 
     if (term.termType === 'Literal') {
       if (term.language) {
-        return `factory.literal(\`${term.value}\`, '${term.language}')`
+        return `literal(\`${term.value}\`, '${term.language}')`
       }
 
       if (term.datatype.value === 'http://www.w3.org/2001/XMLSchema#string') {
-        return `factory.literal(\`${term.value}\`)`
+        return `literal(\`${term.value}\`)`
       }
 
-      return `factory.literal(\`${term.value}\`, factory.namedNode('${term.datatype.value}'))`
+      return `literal(\`${term.value}\`, namedNode('${term.datatype.value}'))`
     }
 
     if (term.termType === 'NamedNode') {
-      return `factory.namedNode('${term.value}')`
+      return `namedNode('${term.value}')`
     }
 
     throw new Error(`unknown term type: ${term.termType}`)
@@ -57,7 +57,7 @@ class PlainSerializer {
       .map(part => `      ${this.serializerTerm(part, blankNodes)}`)
       .join(',\n')
 
-    return `    factory.quad(\n${parts}\n    )`
+    return `    quad(\n${parts}\n    )`
   }
 }
 


### PR DESCRIPTION
By destructuring the factory parameter output JS size can be greatly reduced. I tried with schema.org, which is one of the bigger vocabs and compared the raw size and minified with [UglifyJS 3](https://skalman.github.io/UglifyJS-online/)

| branch | serialised (kB) | minified (kB) |
| -- | -- | -- |
| `master` | ~2361 | ~1771 |
| `destructure-factory`| ~2014 | ~1388 |
| **reduction** | **15%** | **22%** |