### PR TITLE
feat: generate prefix map

### DIFF
--- a/lib/PlainSerializer.js
+++ b/lib/PlainSerializer.js
@@ -1,8 +1,12 @@
+const { getKnownPrefix, getLocalPrefix } = require('./namespaces')
+const safe = require('safe-identifier')
+
 class PlainSerializer {
   transform (quads) {
     const blankNodes = new Map()
+    const namespaces = new Map()
 
-    const quadsString = [...quads].map(quad => this.serializeQuad(quad, blankNodes)).join(',\n')
+    const quadsString = [...quads].map(quad => this.serializeQuad(quad, blankNodes, namespaces)).join(',\n')
 
     const blankNodesString = [
       '  const blankNodes = []',
@@ -12,8 +16,18 @@ class PlainSerializer {
       ''
     ].join('\n')
 
+    const prefixesMapString = [
+      'const {',
+      [...namespaces.values()].map(prefix => `  ${safe.identifier(prefix)}`).join(',\n'),
+      '} = {',
+      [...namespaces.entries()].map(([namespace, prefix]) => `  '${safe.identifier(prefix)}': '${namespace}'`).join(',\n'),
+      '}'
+    ].join('\n')
+
     return [
       '/* This file was automatically generated. Do not edit by hand. */',
+      '',
+      namespaces.size !== 0 ? prefixesMapString : null,
       '',
       'module.exports = ({ blankNode, literal, namedNode, quad }) => {',
       blankNodes.size !== 0 ? blankNodesString : null,
@@ -23,7 +37,7 @@ class PlainSerializer {
     ].filter(part => part !== null).join('\n')
   }
 
-  serializerTerm (term, blankNodes) {
+  serializerTerm (term, blankNodes, namespaces) {
     if (term.termType === 'BlankNode') {
       if (!blankNodes.has(term.value)) {
         blankNodes.set(term.value, blankNodes.size)
@@ -41,20 +55,36 @@ class PlainSerializer {
         return `literal(\`${term.value}\`)`
       }
 
-      return `literal(\`${term.value}\`, namedNode('${term.datatype.value}'))`
+      return `literal(\`${term.value}\`, namedNode(${this.serializeNamedNode(term.datatype, namespaces)}))`
     }
 
     if (term.termType === 'NamedNode') {
-      return `namedNode('${term.value}')`
+      return `namedNode(${this.serializeNamedNode(term, namespaces)})`
     }
 
     throw new Error(`unknown term type: ${term.termType}`)
   }
 
-  serializeQuad (quad, blankNodes) {
+  serializeNamedNode (namedNode, namespaces) {
+    const result = getKnownPrefix(namedNode) || getLocalPrefix(namedNode)
+    if (!result) {
+      return `'${namedNode.value}'`
+    }
+
+    let { prefix, namespace, term } = result
+    if (!prefix) {
+      prefix = namespaces.get(namespace) || `ns${namespaces.size + 1}`
+    }
+
+    namespaces.set(namespace, prefix)
+
+    return '`${' + safe.identifier(prefix) + '}' + term + '`'
+  }
+
+  serializeQuad (quad, blankNodes, namespaces) {
     const parts = [quad.subject, quad.predicate, quad.object, quad.graph]
       .filter(part => part.termType !== 'DefaultGraph')
-      .map(part => `      ${this.serializerTerm(part, blankNodes)}`)
+      .map(part => `      ${this.serializerTerm(part, blankNodes, namespaces)}`)
       .join(',\n')
 
     return `    quad(\n${parts}\n    )`

--- a/lib/namespaces.js
+++ b/lib/namespaces.js
@@ -1,0 +1,35 @@
+const { shrink, prefixes } = require('@zazuko/rdf-vocabularies')
+
+const prefixRegex = /^(\w+):(\w+)?$/
+const namespaceRegex = /((?:.*)(?:[/#]))([^/#]+)$/
+
+function getKnownPrefix (namedNode) {
+  const shrunk = shrink(namedNode.value)
+  if (shrunk) {
+    const matches = shrunk.match(prefixRegex)
+    const prefix = matches[1]
+    const term = matches[2] || ''
+    const namespace = prefixes[prefix]
+
+    return { namespace, prefix, term }
+  }
+
+  return null
+}
+
+function getLocalPrefix (namedNode) {
+  const matches = namedNode.value.match(namespaceRegex)
+  if (!matches.length) {
+    return null
+  }
+
+  const namespace = matches[1]
+  const term = matches[2]
+
+  return { namespace, term }
+}
+
+module.exports = {
+  getKnownPrefix,
+  getLocalPrefix
+}

--- a/package.json
+++ b/package.json
@@ -23,11 +23,14 @@
   "homepage": "https://github.com/rdfjs-base/serializer-rdfjs",
   "dependencies": {
     "@rdfjs/sink": "^1.0.3",
+    "@zazuko/rdf-vocabularies": "latest",
     "get-stream": "^5.1.0",
-    "readable-stream": "^3.6.0"
+    "readable-stream": "^3.6.0",
+    "safe-identifier": "^0.4.1"
   },
   "devDependencies": {
     "@rdfjs/data-model": "^1.1.2",
+    "@tpluscode/rdf-ns-builders": "^0.3.5",
     "into-stream": "^5.1.1",
     "mocha": "^8.0.1",
     "nyc": "^15.1.0",

--- a/test/PlainSerializer.test.js
+++ b/test/PlainSerializer.test.js
@@ -3,6 +3,7 @@ const { describe, it } = require('mocha')
 const toCanonical = require('rdf-dataset-ext/toCanonical')
 const rdf = require('@rdfjs/data-model')
 const PlainSerializer = require('../lib/PlainSerializer')
+const ns = require('@tpluscode/rdf-ns-builders')
 
 describe('PlainSerializer', () => {
   it('should be a constructor', () => {
@@ -76,6 +77,36 @@ describe('PlainSerializer', () => {
           rdf.namedNode('http://example.org/predicate3'),
           rdf.literal('123.0', rdf.namedNode('http://www.w3.org/2001/XMLSchema#double')),
           rdf.namedNode('http://example.org/graph')
+        )
+      ]
+      const serializer = new PlainSerializer()
+      const code = serializer.transform(quads)
+      const result = eval(code)(rdf) /* eslint-disable-line no-eval */
+
+      strictEqual(toCanonical(result), toCanonical(quads))
+    })
+
+    it('should not use reserved words for prefixes', () => {
+      const quads = [
+        rdf.quad(
+          rdf.blankNode(),
+          ns.rdf.type,
+          ns._void.Dataset
+        )
+      ]
+      const serializer = new PlainSerializer()
+      const code = serializer.transform(quads)
+      const result = eval(code)(rdf) /* eslint-disable-line no-eval */
+
+      strictEqual(toCanonical(result), toCanonical(quads))
+    })
+
+    it('should generate prefixes for all named nodes', () => {
+      const quads = [
+        rdf.quad(
+          rdf.namedNode('http://example.com/Foo'),
+          rdf.namedNode('http://example.org/Bar'),
+          rdf.namedNode('http://example.com/Baz')
         )
       ]
       const serializer = new PlainSerializer()


### PR DESCRIPTION
By extracting all named nodes into prefixes (splitting on last segment or hash fragment) the output size can be reduced further

| branch | serialised (kB) | minified (kB) |
| -- | -- | -- |
| `master` | ~2361 | ~1771 |
| `prefixes`| ~2014 | ~1310 |
| **reduction** | **15%** | **26%** |