### PR TITLE
Fixes to named nodes and escaping literals

### DIFF
--- a/lib/PlainSerializer.js
+++ b/lib/PlainSerializer.js
@@ -47,15 +47,19 @@ class PlainSerializer {
     }
 
     if (term.termType === 'Literal') {
+      const value = term.value
+        .replace(/\${/g, '\\${')
+        .replace(/`/g, '\\`')
+
       if (term.language) {
-        return `literal(\`${term.value}\`, '${term.language}')`
+        return `literal(\`${value}\`, '${term.language}')`
       }
 
       if (term.datatype.value === 'http://www.w3.org/2001/XMLSchema#string') {
-        return `literal(\`${term.value}\`)`
+        return `literal(\`${value}\`)`
       }
 
-      return `literal(\`${term.value}\`, namedNode(${this.serializeNamedNode(term.datatype, namespaces)}))`
+      return `literal(\`${value}\`, namedNode(${this.serializeNamedNode(term.datatype, namespaces)}))`
     }
 
     if (term.termType === 'NamedNode') {

--- a/lib/PlainSerializer.js
+++ b/lib/PlainSerializer.js
@@ -78,6 +78,10 @@ class PlainSerializer {
 
     namespaces.set(namespace, prefix)
 
+    if (!term) {
+      return safe.identifier(prefix)
+    }
+
     return '`${' + safe.identifier(prefix) + '}' + term + '`'
   }
 

--- a/lib/namespaces.js
+++ b/lib/namespaces.js
@@ -1,7 +1,7 @@
 const { shrink, prefixes } = require('@zazuko/rdf-vocabularies')
 
 const prefixRegex = /^(\w+):(\w+)?$/
-const namespaceRegex = /((?:.*)(?:[/#]))([^/#]+)$/
+const namespaceRegex = /((?:.*)(?:[/#]))([^/#]*)$/
 
 function getKnownPrefix (namedNode) {
   const shrunk = shrink(namedNode.value)

--- a/test/PlainSerializer.test.js
+++ b/test/PlainSerializer.test.js
@@ -115,5 +115,20 @@ describe('PlainSerializer', () => {
 
       strictEqual(toCanonical(result), toCanonical(quads))
     })
+
+    it('should correctly serialize which end in slashes and hashes', () => {
+      const quads = [
+        rdf.quad(
+          rdf.namedNode('http://example.com/'),
+          rdf.namedNode('http://example.org/vocab#'),
+          rdf.namedNode('http://example.org/foo/')
+        )
+      ]
+      const serializer = new PlainSerializer()
+      const code = serializer.transform(quads)
+      const result = eval(code)(rdf) /* eslint-disable-line no-eval */
+
+      strictEqual(toCanonical(result), toCanonical(quads))
+    })
   })
 })

--- a/test/PlainSerializer.test.js
+++ b/test/PlainSerializer.test.js
@@ -130,5 +130,35 @@ describe('PlainSerializer', () => {
 
       strictEqual(toCanonical(result), toCanonical(quads))
     })
+
+    it('should escape interpolation in literals', () => {
+      const quads = [
+        rdf.quad(
+          rdf.namedNode('http://example.com/'),
+          rdf.namedNode('http://example.org/vocab#'),
+          rdf.literal('${foo} ${bar}')
+        )
+      ]
+      const serializer = new PlainSerializer()
+      const code = serializer.transform(quads)
+      const result = eval(code)(rdf) /* eslint-disable-line no-eval */
+
+      strictEqual(toCanonical(result), toCanonical(quads))
+    })
+
+    it('should escape backticks in literals', () => {
+      const quads = [
+        rdf.quad(
+          rdf.namedNode('http://example.com/'),
+          rdf.namedNode('http://example.org/vocab#'),
+          rdf.literal('`string template`')
+        )
+      ]
+      const serializer = new PlainSerializer()
+      const code = serializer.transform(quads)
+      const result = eval(code)(rdf) /* eslint-disable-line no-eval */
+
+      strictEqual(toCanonical(result), toCanonical(quads))
+    })
   })
 })


### PR DESCRIPTION
Named node which were ending in slash or hash did not serialize

Literals needed escaping of template literals (backticks) and interpolation opening sequence (`${`)