### PR TITLE
fix: prefixed names can have dash

### DIFF
--- a/lib/namespaces.js
+++ b/lib/namespaces.js
@@ -23,7 +23,7 @@ function getKnownPrefix (namedNode) {
 
 function getLocalPrefix (namedNode) {
   const matches = namedNode.value.match(namespaceRegex)
-  if (!matches.length) {
+  if (!matches || !matches.length) {
     return null
   }
 

--- a/lib/namespaces.js
+++ b/lib/namespaces.js
@@ -5,16 +5,20 @@ const namespaceRegex = /((?:.*)(?:[/#]))([^/#]*)$/
 
 function getKnownPrefix (namedNode) {
   const shrunk = shrink(namedNode.value)
-  if (shrunk) {
-    const matches = shrunk.match(prefixRegex)
-    const prefix = matches[1]
-    const term = matches[2] || ''
-    const namespace = prefixes[prefix]
-
-    return { namespace, prefix, term }
+  if (!shrunk) {
+    return null
   }
 
-  return null
+  const matches = shrunk.match(prefixRegex)
+  if (!matches) {
+    return null
+  }
+
+  const prefix = matches[1]
+  const term = matches[2] || ''
+  const namespace = prefixes[prefix]
+
+  return { namespace, prefix, term }
 }
 
 function getLocalPrefix (namedNode) {

--- a/lib/namespaces.js
+++ b/lib/namespaces.js
@@ -1,6 +1,6 @@
 const { shrink, prefixes } = require('@zazuko/rdf-vocabularies')
 
-const prefixRegex = /^(\w+):(\w+)?$/
+const prefixRegex = /^(\w+):([-\w]+)?$/
 const namespaceRegex = /((?:.*)(?:[/#]))([^/#]*)$/
 
 function getKnownPrefix (namedNode) {

--- a/lib/namespaces.js
+++ b/lib/namespaces.js
@@ -1,6 +1,6 @@
 const { shrink, prefixes } = require('@zazuko/rdf-vocabularies')
 
-const prefixRegex = /^(\w+):([-\w]+)?$/
+const prefixRegex = /^(\w+):(.+)?$/
 const namespaceRegex = /((?:.*)(?:[/#]))([^/#]*)$/
 
 function getKnownPrefix (namedNode) {

--- a/test/PlainSerializer.test.js
+++ b/test/PlainSerializer.test.js
@@ -162,6 +162,21 @@ describe('PlainSerializer', () => {
       strictEqual(toCanonical(result), toCanonical(quads))
     })
 
+    it('should correctly match prefixed terms with dash', () => {
+      const quads = [
+        rdf.quad(
+          ns.dash('Action-actionGroup'),
+          ns.rdf.type,
+          ns.sh.PropertyShape
+        )
+      ]
+      const serializer = new PlainSerializer()
+      const code = serializer.transform(quads)
+      const result = eval(code)(rdf) /* eslint-disable-line no-eval */
+
+      strictEqual(toCanonical(result), toCanonical(quads))
+    })
+
     it('should write commonjs by default', () => {
       const serializer = new PlainSerializer()
 

--- a/test/PlainSerializer.test.js
+++ b/test/PlainSerializer.test.js
@@ -177,6 +177,21 @@ describe('PlainSerializer', () => {
       strictEqual(toCanonical(result), toCanonical(quads))
     })
 
+    it('should gracefully handle unprefixable named nodes', () => {
+      const quads = [
+        rdf.quad(
+          rdf.blankNode(),
+          ns.vcard.email,
+          rdf.namedNode('mailto:edd@usefulinc.com')
+        )
+      ]
+      const serializer = new PlainSerializer()
+      const code = serializer.transform(quads)
+      const result = eval(code)(rdf) /* eslint-disable-line no-eval */
+
+      strictEqual(toCanonical(result), toCanonical(quads))
+    })
+
     it('should write commonjs by default', () => {
       const serializer = new PlainSerializer()
 


### PR DESCRIPTION
No pun intended, `dash` namespace contains term with dashes, which were incorrectly matched by a regular expression