### PR TITLE
fix: use `@rdfjs/types`

### DIFF
--- a/lib/writer/TypeScriptWriter.js
+++ b/lib/writer/TypeScriptWriter.js
@@ -1,13 +1,13 @@
 class TypeScriptWriter {
   leadingLines () {
     return [
-      'export default ({ factory }: { factory: import(\'rdf-js\').DataFactory }): import(\'rdf-js\').Quad[] => {'
+      'export default ({ factory }: { factory: import(\'@rdfjs/types\').DataFactory }): import(\'@rdfjs/types\').Quad[] => {'
     ]
   }
 
   blankNodesLines (number) {
     return [
-      '  const blankNodes: import(\'rdf-js\').BlankNode[] = []',
+      '  const blankNodes: import(\'@rdfjs/types\').BlankNode[] = []',
       `  for (let i = 0; i < ${number}; i++) {`,
       '    blankNodes.push(f.blankNode())',
       '  }',

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/rdfjs-base/serializer-rdfjs",
   "dependencies": {
     "@rdfjs/sink": "^2.0.0",
+    "@rdfjs/types": "^1.1.0",
     "js-string-escape": "^1.0.1",
     "readable-stream": "^4.3.0",
     "stream-chunks": "^1.0.0"

--- a/test/support/example.empty.ts
+++ b/test/support/example.empty.ts
@@ -1,5 +1,5 @@
 /* This file was automatically generated. Do not edit by hand. */
 
-export default ({ factory }: { factory: import('rdf-js').DataFactory }): import('rdf-js').Quad[] => {
+export default ({ factory }: { factory: import('@rdfjs/types').DataFactory }): import('@rdfjs/types').Quad[] => {
   return []
 }

--- a/test/support/example.simple.ts
+++ b/test/support/example.simple.ts
@@ -1,10 +1,10 @@
 /* This file was automatically generated. Do not edit by hand. */
 
-export default ({ factory }: { factory: import('rdf-js').DataFactory }): import('rdf-js').Quad[] => {
+export default ({ factory }: { factory: import('@rdfjs/types').DataFactory }): import('@rdfjs/types').Quad[] => {
   const f = factory
   const ns1 = 'http://example.org/'
   const ns2 = 'http://www.w3.org/2001/XMLSchema#'
-  const blankNodes: import('rdf-js').BlankNode[] = []
+  const blankNodes: import('@rdfjs/types').BlankNode[] = []
   for (let i = 0; i < 2; i++) {
     blankNodes.push(f.blankNode())
   }


### PR DESCRIPTION
Uses `@rdfjs/types` instead of the deprecated rdf-js package

cc @tpluscode 